### PR TITLE
Cleanup

### DIFF
--- a/eksbuild.tf
+++ b/eksbuild.tf
@@ -87,14 +87,13 @@ resource "null_resource" "smart-check" {
             https://github.com/deep-security/smartcheck-helm/archive/master.tar.gz
         EOT
     }
-}
-
-resource "null_resource" "cleanup" {
     provisioner "local-exec" {
-        on_destroy = "attempt"
+        when = "destroy"
         command = <<EOT
         sleep 10
+        helm delete --purge deepsecurity-smartcheck
+        sleep 10
         EOT
-        
+
     }
 }

--- a/eksbuild.tf
+++ b/eksbuild.tf
@@ -88,3 +88,13 @@ resource "null_resource" "smart-check" {
         EOT
     }
 }
+
+resource "null_resource" "cleanup" {
+    provisioner "local-exec" {
+        on_destroy = "attempt"
+        command = <<EOT
+        sleep 10
+        EOT
+        
+    }
+}


### PR DESCRIPTION
Fix for issue #5.

Added on destroy provisioner to remove SmartCheck deployment. Removes leftover volumes, load balancer and pvc volumes created by smartcheck deployment. 